### PR TITLE
Fix53

### DIFF
--- a/Driver Code/DevDeploy.bat
+++ b/Driver Code/DevDeploy.bat
@@ -14,6 +14,6 @@ rem       @"LINQPad\Drivers\DataContext\3.5\")
 rem
 rem  The final part of the directory is the name of the assembly plus its public key token in brackets.
 echo 3.5 b094696bc21c000a
-xcopy /i/y *.dll "C:\ProgramData\LINQPad\Drivers\DataContext\3.5\SD.LLBLGen.Pro.LINQPadDriver50 (b094696bc21c000a)"
-xcopy /i/y *.pdb "C:\ProgramData\LINQPad\Drivers\DataContext\3.5\SD.LLBLGen.Pro.LINQPadDriver50 (b094696bc21c000a)"
+xcopy /i/y *.dll "C:\ProgramData\LINQPad\Drivers\DataContext\3.5\SD.LLBLGen.Pro.LINQPadDriver53 (b094696bc21c000a)"
+xcopy /i/y *.pdb "C:\ProgramData\LINQPad\Drivers\DataContext\3.5\SD.LLBLGen.Pro.LINQPadDriver53 (b094696bc21c000a)"
 pause

--- a/Driver Code/DevDeploy4.bat
+++ b/Driver Code/DevDeploy4.bat
@@ -15,6 +15,6 @@ rem       @"LINQPad\Drivers\DataContext\3.5\")
 rem
 rem  The final part of the directory is the name of the assembly plus its public key token in brackets.
 echo 4.0 b094696bc21c000a
-xcopy /i/y *.dll "C:\ProgramData\LINQPad\Drivers\DataContext\4.0\SD.LLBLGen.Pro.LINQPadDriver50 (b094696bc21c000a)"
-xcopy /i/y *.pdb "C:\ProgramData\LINQPad\Drivers\DataContext\4.0\SD.LLBLGen.Pro.LINQPadDriver50 (b094696bc21c000a)"
+xcopy /i/y *.dll "C:\ProgramData\LINQPad\Drivers\DataContext\4.0\SD.LLBLGen.Pro.LINQPadDriver53 (b094696bc21c000a)"
+xcopy /i/y *.pdb "C:\ProgramData\LINQPad\Drivers\DataContext\4.0\SD.LLBLGen.Pro.LINQPadDriver53 (b094696bc21c000a)"
 pause

--- a/Driver Code/DevDeploy5.bat
+++ b/Driver Code/DevDeploy5.bat
@@ -1,0 +1,13 @@
+@Echo off
+rem
+rem  You can simplify development by updating this batch file and then calling it from the 
+rem  project's post-build event.
+rem
+rem  It copies the output .DLL (and .PDB) to LINQPad's drivers folder, so that LINQPad
+rem  picks up the drivers immediately (without needing to click 'Add Driver').
+rem
+rem  The final part of the directory is the name of the assembly plus its public key token in brackets.
+echo 5.0 b094696bc21c000a
+xcopy /i/y *.dll "%localappdata%\LINQPad\Drivers\DataContext\4.6\SD.LLBLGen.Pro.LINQPadDriver53 (b094696bc21c000a)"
+xcopy /i/y *.pdb "%localappdata%\LINQPad\Drivers\DataContext\4.6\SD.LLBLGen.Pro.LINQPadDriver53 (b094696bc21c000a)"
+pause

--- a/Driver Code/LINQPadDriver.csproj
+++ b/Driver Code/LINQPadDriver.csproj
@@ -77,6 +77,7 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="DevDeploy.bat" />
+    <None Include="DevDeploy5.bat" />
     <None Include="DevDeploy4.bat" />
     <None Include="packages.config" />
     <None Include="StrongName.snk" />
@@ -97,7 +98,8 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PostBuildEvent>Call "$(ProjectDir)\DevDeploy4.bat"
+    <PostBuildEvent>Call "$(ProjectDir)\DevDeploy5.bat"
+Call "$(ProjectDir)\DevDeploy4.bat"
 Call "$(ProjectDir)\DevDeploy.bat"
 </PostBuildEvent>
   </PropertyGroup>


### PR DESCRIPTION
Adds support(deploy) for LINQPad 5.
Fixes deploy paths to ...53.